### PR TITLE
Fix uploads in Firefox<44

### DIFF
--- a/backend/backend-server.py
+++ b/backend/backend-server.py
@@ -5,7 +5,7 @@ import base64
 import hmac
 import hashlib
 from requestsigner import AwsV2Auth
-from urlparse       import urlparse
+from urlparse       import urlparse, parse_qs
 from time           import time
 
 KEY = "XXX"
@@ -19,8 +19,8 @@ class TokenRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             return SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)
 
         query = urlparse(self.path).query
-        query_components = dict(qc.split("=") for qc in query.split("&"))
-        ct = query_components["contentType"]
+        query_components = parse_qs(query)
+        ct = query_components["contentType"][0]
 
 
         key = base64.b32encode(hmac.new(str(time()), "1", hashlib.sha512).digest())[0:30]

--- a/client/fileprocessing.js
+++ b/client/fileprocessing.js
@@ -31,7 +31,7 @@ function requestUploadToken(file) {
     function(resolve, reject) {
       var content_type = file.type;
       var client = new XMLHttpRequest();
-      client.open('GET', "token/?contentType="+"application/pgp-encrypted");
+      client.open('GET', "token/?contentType="+ encodeURIComponent("application/pgp-encrypted; charset=UTF-8"));
 
       client.onreadystatechange = function() {
         if (client.readyState != 4) {
@@ -57,7 +57,7 @@ function objStorageUpload (ciphertext, contentType, uploadURL){
     function(resolve, reject) {
       var client = new XMLHttpRequest();
       client.open('PUT', uploadURL)
-      client.setRequestHeader("Content-Type", "application/pgp-encrypted");
+      client.setRequestHeader("Content-Type", "application/pgp-encrypted; charset=UTF-8");
       client.onreadystatechange = function() {
         if (client.readyState != 4) {
           return;


### PR DESCRIPTION
Firefox incorrectly attaches a charset when setting the Content-Type header.
Work around this limitation by always attaching a content-type to prevent
signature errors.
